### PR TITLE
Changed the `TOML` table to a loadable module chunk. 

### DIFF
--- a/toml.lua
+++ b/toml.lua
@@ -1,4 +1,4 @@
-TOML = {
+return {
 	strict = true,
 
 	version = 0.31,


### PR DESCRIPTION
A table load can cause the loaded chunk to be reloaded each time a call is done, due to the copy call in `load()`. It can also cause multiple modules that use the `toml table` to load on each instance, resulting in increase memory usage and increase in processing time.

Instead, a simple return of the table can remedy this whole problem and make it easier to use.