### PR TITLE
Lua 5.1 marked as supported in the rockspec.

### DIFF
--- a/rockspecs/lua-toml-1.0-0.rockspec
+++ b/rockspecs/lua-toml-1.0-0.rockspec
@@ -12,7 +12,7 @@ TOML 0.4.0 compliant Lua library with tests. Serializes TOML into a Lua table, a
 	license = "The Happy License",
 }
 dependencies = {
-	"lua >= 5.2"
+	"lua >= 5.1"
 }
 build = {
 	type = "builtin",


### PR DESCRIPTION
Considering it passes the busted tests with Lua 5.1, I’d say there’s not reason to prevent installation for 5.1 through luarocks.