### PR TITLE
Fix string encoding when encoding arrays

### DIFF
--- a/spec/encode_spec.lua
+++ b/spec/encode_spec.lua
@@ -5,7 +5,7 @@ describe("encoding", function()
 
 	it("array", function()
 		local obj = TOML.encode{ a = { "foo","bar" } }
-		local sol = "a = [\nfoo,\nbar,\n]"
+		local sol = "a = [\n\"foo\",\n\"bar\",\n]"
 		assert.same(sol, obj)
 	end)
 end)

--- a/toml.lua
+++ b/toml.lua
@@ -619,8 +619,13 @@ TOML.encode = function(tbl)
 					else
 						-- plain ol boring array
 						toml = toml .. k .. " = [\n"
+						local quote = '"'
 						for kk, vv in pairs(first) do
-							toml = toml .. tostring(vv) .. ",\n"
+							if type(vv) == "string" then
+								toml = toml .. quote .. tostring(vv) .. quote .. ",\n"
+							else
+								toml = toml .. tostring(vv) .. ",\n"
+							end
 						end
 						toml = toml .. "]\n"
 					end


### PR DESCRIPTION
Closes #18 

Add quotes when encoding strings inside arrays. Simple and straightforward. Please let me know if there are any issues with my solution or if you want commits to be a certain way.