### PR TITLE
Fix nested tables in table arrays

### DIFF
--- a/spec/table-array_spec.lua
+++ b/spec/table-array_spec.lua
@@ -93,4 +93,43 @@ last_name = "Springsteen"]=]
 		}
 		assert.same(sol, obj)
 	end)
+
+	it("nest-tables", function()
+		local obj = TOML.parse[=[
+[[people]]
+first_name = "Bruce"
+last_name = "Springsteen"
+
+[people.birth]
+date = "September 23, 1949"
+place = "Long Branch, New Jersey"
+
+[people.spouse]
+first_name = "Patti"
+last_name = "Scialfa"
+
+[[people]]
+# an empty element
+
+[[people]]
+first_name = "Eric"
+last_name = "Clapton"
+]=]
+		local sol = {
+			people = {
+				{
+					first_name = "Bruce", last_name = "Springsteen",
+					birth = {
+						date = "September 23, 1949",
+						place = "Long Branch, New Jersey"
+					},
+					spouse = { first_name = "Patti", last_name = "Scialfa" },
+				}, {
+				}, {
+					first_name = "Eric", last_name = "Clapton"
+				}
+			}
+		}
+		assert.same(sol, obj)
+	end)
 end)

--- a/toml.lua
+++ b/toml.lua
@@ -511,8 +511,15 @@ TOML.parse = function(toml, options)
 						end
 					end
 				else
-					obj[buffer] = obj[buffer] or {}
-					obj = obj[buffer]
+					local newObj = obj[buffer] or {}
+					obj[buffer] = newObj
+					if #newObj > 0 then
+						-- an array is already in progress for this key, so modify its
+						-- last element, instead of the array itself
+						obj = newObj[#newObj]
+					else
+						obj = newObj
+					end
 				end
 			end
 


### PR DESCRIPTION
Fix parsing nested tables within table arrays so their keys are applied
to the last element, not the array itself.

Add a test that ensures nested tables in arrays produces the proper
output.

Fixes #20.