### PR TITLE
Fix creating table array in existing table

### DIFF
--- a/spec/table-array_spec.lua
+++ b/spec/table-array_spec.lua
@@ -93,4 +93,22 @@ last_name = "Springsteen"]=]
 		}
 		assert.same(sol, obj)
 	end)
+
+	it("existing", function()
+		local obj = TOML.parse[=[
+[album]
+name = "Swimming"
+
+[[album.tracks]]
+name = "Wings"]=]
+		local sol = {
+			album = {
+				name = "Swimming",
+				tracks = {
+					{name = "Wings"}
+				}
+			}
+		}
+		assert.same(sol, obj)
+	end)
 end)

--- a/toml.lua
+++ b/toml.lua
@@ -500,8 +500,8 @@ TOML.parse = function(toml, options)
 						obj = obj[buffer]
 						if isLast then
 							table.insert(obj, {})
+							obj = obj[#obj]
 						end
-						obj = obj[#obj]
 					else
 						obj[buffer] = {}
 						obj = obj[buffer]


### PR DESCRIPTION
For instance this did not work before:
```toml
[t]
name = "test"

[[t.ent]]
ok = "foo"
```