### PR TITLE
Don't replace / with \\/, because the library can't decode that back

### DIFF
--- a/toml.lua
+++ b/toml.lua
@@ -586,7 +586,6 @@ TOML.encode = function(tbl)
 				v = v:gsub("\f", "\\f")
 				v = v:gsub("\r", "\\r")
 				v = v:gsub('"', '\\"')
-				v = v:gsub("/", "\\/")
 				toml = toml .. k .. " = " .. quote .. v .. quote .. "\n"
 			elseif type(v) == "table" then
 				local array, arrayTable = true, true


### PR DESCRIPTION
I'm not sure why that was in, but the lirary can't understand it itself when it decodes these strings back.